### PR TITLE
Ensure camelCase options for Supabase upload

### DIFF
--- a/core/supabase_client.py
+++ b/core/supabase_client.py
@@ -23,7 +23,12 @@ def upload_bytes(data: bytes, path: str, content_type: str | None = None, *, buc
     bucket_name = bucket or os.getenv("SUPABASE_BUCKET", "uploads")
     if content_type is None:
         content_type = guess_mime(path) or "application/octet-stream"
-    client.storage.from_(bucket_name).upload(path, data, {'content-type': content_type, 'cache-control': 'max-age=3600'})
+    # Supabase expects camelCase keys such as `contentType` and `cacheControl`
+    options = {
+        "contentType": content_type,
+        "cacheControl": "3600",
+    }
+    client.storage.from_(bucket_name).upload(path, data, options)
 
 
 def create_signed_url(path: str, seconds: int = 7200, *, bucket: str | None = None) -> str:


### PR DESCRIPTION
## Summary
- use `cacheControl` instead of deprecated `cache-control` header
- add comment clarifying camelCase option names and use `contentType`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab5f9d15dc83249ce55f3f99d6d657